### PR TITLE
add meta community Rheinufer

### DIFF
--- a/app/01_models/region.rb
+++ b/app/01_models/region.rb
@@ -14,6 +14,7 @@ class Region < Struct.new(:key, :name, :zoom, :location, :data_url, :twitter, :h
     Region.new(:chemnitz,     "Chemnitz",       10, [50.82, 12.89], "http://curie.routers.chemnitz.freifunk.net/ffmap-d3/nodes.json", "FreifunkC",        "http://chemnitz.freifunk.net/"),
     Region.new(:ffrn,         "Rhein-Neckar",    9, [49.51,  8.56], "http://map.freifunk-rhein-neckar.de/nodes.json",                 "FFRheinNeckar",    "http://www.freifunk-rhein-neckar.de/"),
     Region.new(:ruhr,         "Ruhrgebiet",      8, [51.47,  7.11], "http://map.freifunk-ruhrgebiet.de/nodes.json",                   "ffruhr",           "http://freifunk-ruhrgebiet.de/"),
+    Region.new(:rheinland,    "Rheinland",       8, [51.22,  6.77], "http://ffmap.freifunk-rheinland.net/nodes.json",                 "FFRhein",          "http://freifunk-rheinland.net/"),
     Region.new(:moehne,       "Soest+HSK",       8, [51.49,  8.13], "http://moehne-vis.freifunk-rheinland.net/map/nodes.json",        "FFMoehne",         "http://freifunk-moehne.de/"),
     Region.new(:muenster,     "Münster",         8, [51.95,  7.62], "http://freifunk-muenster.de/map/nodes.json",                     "Freifunk_MS",      "http://freifunk-muenster.de/"),
     Region.new(:braunschweig, "Braunschweig",   10, [52.27, 10.53], "http://freifunk-bs.de/nodes_compat.json",                        "freifunk_bs",      "http://freifunk-bs.de/"),


### PR DESCRIPTION
Rheinufer is a meta community from Freifunk Rheinland e.V.